### PR TITLE
Reviewed changes for reducing warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,23 @@ sudo: false
 env:
   - IDE_VERSION=1.8.7
 
+cache:
+  directories:
+  - $HOME/.arduino15
+  - $HOME/arduino_ide
+
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
   - sleep 3
   - export DISPLAY=:1.0
   - export ARDUINO_IDE=arduino_ide/${IDE_VERSION}
+  - export ARDUINO_LIBS="$HOME/Arduino/libraries"
   - if [ ! -d "$HOME/arduino_ide" ] ; then mkdir "$HOME/arduino_ide" ; fi
   - if [ ! -d "$HOME/$ARDUINO_IDE" ] ; then { echo "fetch" && wget http://downloads.arduino.cc/arduino-${IDE_VERSION}-linux64.tar.xz && echo "untar" && tar xf arduino-${IDE_VERSION}-linux64.tar.xz && echo "move" && mv -f arduino-${IDE_VERSION} $HOME/${ARDUINO_IDE} ; } || { echo "IDE install failed"; exit 1; } ; else echo "IDE already installed" ; fi
   - ln -sf $PWD $HOME/${ARDUINO_IDE}/libraries/Test_Library
   - export PATH="$HOME/${ARDUINO_IDE}:$PATH"
+  # clean up for earlier bugs. This is transitional.
+  - rm -rf $HOME/${ARDUINO_IDE}/libraries/Adafruit_Sensor $HOME/${ARDUINO_IDE}/libraries/DHT-sensor-library
   #
   # functions to generate the board settings for SAMD, STM32L0, ...
   # keep args for these aligned for any common options. $1 is always board name, $2 is region.
@@ -51,21 +59,15 @@ before_install:
   - "echo $(_avropts) $(_avropts '' PROJCFG)"
   - "echo $(_esp32opts) $(_esp32opts '' PROJCFG)"
 
-
 install:
- - git clone --depth=1 https://github.com/adafruit/Adafruit_Sensor.git $HOME/${ARDUINO_IDE}/libraries/Adafruit_Sensor
- - git clone --depth=1 https://github.com/adafruit/DHT-sensor-library.git $HOME/${ARDUINO_IDE}/libraries/DHT-sensor-library
+ - git clone --depth=1 https://github.com/adafruit/Adafruit_Sensor.git $ARDUINO_LIBS/libraries/Adafruit_Sensor
+ - git clone --depth=1 https://github.com/adafruit/DHT-sensor-library.git $ARDUINO_LIBS/libraries/DHT-sensor-library
  # be careful when installing; with caching, we usually won't update. Select most recent.
  - arduino --install-boards adafruit:avr || echo "assume adafruit:avr already installed, continue"
  - arduino --install-boards mcci:samd || echo "assume mcci:samd already installed, continue"
  - arduino --install-boards mcci:stm32 || echo "assume mcci:samd already installed, continue"
  - arduino --install-boards esp32:esp32 || echo "assume esp32:esp32 already installed, condtinue"
  - 'if [ -d $HOME/.arduino15/packages/mcci/hardware/stm32/1.1.0 ]; then echo "Work around broken BSP version 1.1.0" ; export MCCI_STM32_OPTS="$MCCI_STM32_OPTS --pref build.board=CATENA_4551" ; fi'
-
-cache:
-  directories:
-  - $HOME/.arduino15
-  - $HOME/arduino_ide
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ before_install:
   - "echo $(_esp32opts) $(_esp32opts '' PROJCFG)"
 
 install:
- - git clone --depth=1 https://github.com/adafruit/Adafruit_Sensor.git $ARDUINO_LIBS/libraries/Adafruit_Sensor
- - git clone --depth=1 https://github.com/adafruit/DHT-sensor-library.git $ARDUINO_LIBS/libraries/DHT-sensor-library
+ - git clone --depth=1 https://github.com/adafruit/Adafruit_Sensor.git $ARDUINO_LIBS/Adafruit_Sensor
+ - git clone --depth=1 https://github.com/adafruit/DHT-sensor-library.git $ARDUINO_LIBS/DHT-sensor-library
  # be careful when installing; with caching, we usually won't update. Select most recent.
  - arduino --install-boards adafruit:avr || echo "assume adafruit:avr already installed, continue"
  - arduino --install-boards mcci:samd || echo "assume mcci:samd already installed, continue"

--- a/src/aes/ideetron/AES-128_V10.cpp
+++ b/src/aes/ideetron/AES-128_V10.cpp
@@ -85,7 +85,6 @@ static unsigned char AES_Sub_Byte(unsigned char Byte);
 static void AES_Shift_Rows();
 static void AES_Mix_Collums();
 static void AES_Calculate_Round_Key(unsigned char Round, unsigned char *Round_Key);
-static void Send_State();
 
 /*
 *****************************************************************************************

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -47,7 +47,9 @@ static void engineUpdate(void);
 static void startScan (void);
 #endif
 
-static inline void initTxrxFlags(UNUSED_VAR const char *func, u1_t mask) {
+static inline void initTxrxFlags(const char *func, u1_t mask) {
+	LMIC_DEBUG2_PARAMETER(func);
+
 #if LMIC_DEBUG_LEVEL > 1
 	LMIC_DEBUG_PRINTF("%"PRId32": %s txrxFlags %#02x --> %02x\n", os_getTime(), func, LMIC.txrxFlags, mask);
 #endif
@@ -413,7 +415,9 @@ static void txDelay (ostime_t reftime, u1_t secSpan) {
 }
 
 
-void LMICcore_setDrJoin (UNUSED_VAR u1_t reason, u1_t dr) {
+void LMICcore_setDrJoin (u1_t reason, u1_t dr) {
+    LMIC_EV_PARAMETER(reason);
+
     EV(drChange, INFO, (e_.reason    = reason,
                         e_.deveui    = MAIN::CDEV->getEui(),
                         e_.dr        = dr|DR_PAGE,
@@ -425,7 +429,9 @@ void LMICcore_setDrJoin (UNUSED_VAR u1_t reason, u1_t dr) {
 }
 
 
-static void setDrTxpow (UNUSED_VAR u1_t reason, u1_t dr, s1_t pow) {
+static void setDrTxpow (u1_t reason, u1_t dr, s1_t pow) {
+    LMIC_EV_PARAMETER(reason);
+
     EV(drChange, INFO, (e_.reason    = reason,
                         e_.deveui    = MAIN::CDEV->getEui(),
                         e_.dr        = dr|DR_PAGE,
@@ -461,7 +467,9 @@ void LMIC_setPingable (u1_t intvExp) {
 
 #endif // !DISABLE_PING
 
-static void runEngineUpdate (UNUSED_VAR xref2osjob_t osjob) {
+static void runEngineUpdate (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     engineUpdate();
 }
 
@@ -475,7 +483,9 @@ static void reportEvent (ev_t ev) {
 }
 
 
-static void runReset (UNUSED_VAR xref2osjob_t osjob) {
+static void runReset (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     // Disable session
     LMIC_reset();
 #if !defined(DISABLE_JOIN)
@@ -1019,7 +1029,9 @@ static void txDone (ostime_t delay, osjobcb_t func) {
 
 
 #if !defined(DISABLE_JOIN)
-static void onJoinFailed (UNUSED_VAR xref2osjob_t osjob) {
+static void onJoinFailed (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     // Notify app - must call LMIC_reset() to stop joining
     // otherwise join procedure continues.
     reportEvent(EV_JOIN_FAILED);
@@ -1072,7 +1084,9 @@ static bit_t processJoinAccept (void) {
     }
     u1_t hdr  = LMIC.frame[0];
     u1_t dlen = LMIC.dataLen;
-    UNUSED_VAR u4_t mic  = os_rlsbf4(&LMIC.frame[dlen-4]); // safe before modified by encrypt!
+    u4_t mic  = os_rlsbf4(&LMIC.frame[dlen-4]); // safe before modified by encrypt!
+    LMIC_EV_VARIABLE(mic);                      // only used by EV().
+
     if( (dlen != LEN_JA && dlen != LEN_JAEXT)
         || (hdr & (HDR_FTYPE|HDR_MAJOR)) != (HDR_FTYPE_JACC|HDR_MAJOR_V1) ) {
         EV(specCond, ERR, (e_.reason = EV::specCond_t::UNEXPECTED_FRAME,
@@ -1160,7 +1174,9 @@ static bit_t processJoinAccept (void) {
 }
 
 
-static void processRx2Jacc (UNUSED_VAR xref2osjob_t osjob) {
+static void processRx2Jacc (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
     }
@@ -1168,24 +1184,32 @@ static void processRx2Jacc (UNUSED_VAR xref2osjob_t osjob) {
 }
 
 
-static void setupRx2Jacc (UNUSED_VAR xref2osjob_t osjob) {
+static void setupRx2Jacc (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     LMIC.osjob.func = FUNC_ADDR(processRx2Jacc);
     setupRx2();
 }
 
 
-static void processRx1Jacc (UNUSED_VAR xref2osjob_t osjob) {
+static void processRx1Jacc (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     if( LMIC.dataLen == 0 || !processJoinAccept() )
         schedRx12(DELAY_JACC2_osticks, FUNC_ADDR(setupRx2Jacc), LMIC.dn2Dr);
 }
 
 
-static void setupRx1Jacc (UNUSED_VAR xref2osjob_t osjob) {
+static void setupRx1Jacc (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     setupRx1(FUNC_ADDR(processRx1Jacc));
 }
 
 
-static void jreqDone (UNUSED_VAR xref2osjob_t osjob) {
+static void jreqDone (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     txDone(DELAY_JACC1_osticks, FUNC_ADDR(setupRx1Jacc));
 }
 
@@ -1196,11 +1220,15 @@ static void jreqDone (UNUSED_VAR xref2osjob_t osjob) {
 // Fwd decl.
 static bit_t processDnData(void);
 
-static void processRx2DnDataDelay (UNUSED_VAR xref2osjob_t osjob) {
+static void processRx2DnDataDelay (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     processDnData();
 }
 
-static void processRx2DnData (UNUSED_VAR xref2osjob_t osjob) {
+static void processRx2DnData (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
         // Delay callback processing to avoid up TX while gateway is txing our missed frame!
@@ -1214,24 +1242,32 @@ static void processRx2DnData (UNUSED_VAR xref2osjob_t osjob) {
 }
 
 
-static void setupRx2DnData (UNUSED_VAR xref2osjob_t osjob) {
+static void setupRx2DnData (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     LMIC.osjob.func = FUNC_ADDR(processRx2DnData);
     setupRx2();
 }
 
 
-static void processRx1DnData (UNUSED_VAR xref2osjob_t osjob) {
+static void processRx1DnData (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     if( LMIC.dataLen == 0 || !processDnData() )
         schedRx12(sec2osticks(LMIC.rxDelay +(int)DELAY_EXTDNW2), FUNC_ADDR(setupRx2DnData), LMIC.dn2Dr);
 }
 
 
-static void setupRx1DnData (UNUSED_VAR xref2osjob_t osjob) {
+static void setupRx1DnData (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     setupRx1(FUNC_ADDR(processRx1DnData));
 }
 
 
-static void updataDone (UNUSED_VAR xref2osjob_t osjob) {
+static void updataDone (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     txDone(sec2osticks(LMIC.rxDelay), FUNC_ADDR(setupRx1DnData));
 }
 
@@ -1376,7 +1412,9 @@ static void buildDataFrame (void) {
 
 #if !defined(DISABLE_BEACONS)
 // Callback from HAL during scan mode or when job timer expires.
-static void onBcnRx (UNUSED_VAR xref2osjob_t job) {
+static void onBcnRx (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     // If we arrive via job timer make sure to put radio to rest.
     os_radio(RADIO_RST);
     os_clearCallback(&LMIC.osjob);
@@ -1496,7 +1534,9 @@ static void buildJoinRequest (u1_t ftype) {
     DO_DEVDB(LMIC.devNonce,devNonce);
 }
 
-static void startJoining (UNUSED_VAR xref2osjob_t osjob) {
+static void startJoining (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     reportEvent(EV_JOINING);
 }
 
@@ -1529,7 +1569,9 @@ bit_t LMIC_startJoining (void) {
 // ================================================================================
 
 #if !defined(DISABLE_PING)
-static void processPingRx (UNUSED_VAR xref2osjob_t osjob) {
+static void processPingRx (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     if( LMIC.dataLen != 0 ) {
         initTxrxFlags(__func__, TXRX_PING);
         if( decodeFrame() ) {
@@ -1610,7 +1652,9 @@ static bit_t processDnData (void) {
 
 
 #if !defined(DISABLE_BEACONS)
-static void processBeacon (UNUSED_VAR xref2osjob_t osjob) {
+static void processBeacon (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     ostime_t lasttx = LMIC.bcninfo.txtime;   // save here - decodeBeacon might overwrite
     u1_t flags = LMIC.bcninfo.flags;
     ev_t ev;
@@ -1671,7 +1715,9 @@ static void processBeacon (UNUSED_VAR xref2osjob_t osjob) {
 }
 
 
-static void startRxBcn (UNUSED_VAR xref2osjob_t osjob) {
+static void startRxBcn (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     LMIC.osjob.func = FUNC_ADDR(processBeacon);
     os_radio(RADIO_RX);
 }
@@ -1679,7 +1725,9 @@ static void startRxBcn (UNUSED_VAR xref2osjob_t osjob) {
 
 
 #if !defined(DISABLE_PING)
-static void startRxPing (UNUSED_VAR xref2osjob_t osjob) {
+static void startRxPing (xref2osjob_t osjob) {
+    LMIC_API_PARAMETER(osjob);
+
     LMIC.osjob.func = FUNC_ADDR(processPingRx);
     os_radio(RADIO_RX);
 }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -31,7 +31,6 @@
 //! \file
 #define LMIC_DR_LEGACY 0
 #include "lmic_bandplan.h"
-#include "inttypes.h"
 
 #if defined(DISABLE_BEACONS) && !defined(DISABLE_PING)
 #error Ping needs beacon tracking
@@ -51,7 +50,7 @@ static inline void initTxrxFlags(const char *func, u1_t mask) {
 	LMIC_DEBUG2_PARAMETER(func);
 
 #if LMIC_DEBUG_LEVEL > 1
-	LMIC_DEBUG_PRINTF("%"PRId32": %s txrxFlags %#02x --> %02x\n", os_getTime(), func, LMIC.txrxFlags, mask);
+	LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": %s txrxFlags %#02x --> %02x\n", os_getTime(), func, LMIC.txrxFlags, mask);
 #endif
 	LMIC.txrxFlags = mask;
 }
@@ -582,7 +581,7 @@ scan_mac_cmds(
             // of contiguous commands (whatever that means), and ignore the
             // data rate, NbTrans (uprpt) and txPow until the last one.
 #if LMIC_DEBUG_LEVEL > 0
-            LMIC_DEBUG_PRINTF("%"PRId32": LinkAdrReq: p1:%02x chmap:%04x chpage:%02x uprt:%02x ans:%02x\n",
+            LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": LinkAdrReq: p1:%02x chmap:%04x chpage:%02x uprt:%02x ans:%02x\n",
 		os_getTime(), p1, chmap, chpage, uprpt, LMIC.ladrAns
 		);
 #endif /* LMIC_DEBUG_LEVEL */
@@ -745,7 +744,7 @@ static bit_t decodeFrame (void) {
                             e_.info2  = hdr + (dlen<<8)));
       norx:
 #if LMIC_DEBUG_LEVEL > 0
-        LMIC_DEBUG_PRINTF("%"PRId32": Invalid downlink, window=%s\n", os_getTime(), window);
+        LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": Invalid downlink, window=%s\n", os_getTime(), window);
 #endif
         LMIC.dataLen = 0;
         return 0;
@@ -837,7 +836,7 @@ static bit_t decodeFrame (void) {
 
 #if LMIC_DEBUG_LEVEL > 0
     // Process OPTS
-    LMIC_DEBUG_PRINTF("%"PRId32": process options (olen=%#x)\n", os_getTime(), olen);
+    LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": process options (olen=%#x)\n", os_getTime(), olen);
 #endif
 
     xref2u1_t opts = &d[OFF_DAT_OPTS];
@@ -856,13 +855,13 @@ static bit_t decodeFrame (void) {
             if (port == 0) {
                 // this is a mac command. scan the options.
 #if LMIC_DEBUG_LEVEL > 0
-                LMIC_DEBUG_PRINTF("%"PRId32": process mac commands for port 0 (olen=%#x)\n", os_getTime(), pend-poff);
+                LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": process mac commands for port 0 (olen=%#x)\n", os_getTime(), pend-poff);
 #endif
                 int optendindex = scan_mac_cmds(d+poff, pend-poff);
                 if (optendindex != pend-poff) {
 #if LMIC_DEBUG_LEVEL > 0
                     LMIC_DEBUG_PRINTF(
-                        "%"PRId32": error processing mac commands for port 0 "
+                        "%"LMIC_PRId_ostime_t": error processing mac commands for port 0 "
                         "(len=%#x, optendindex=%#x)\n",
                         os_getTime(), pend-poff, optendindex
                         );
@@ -899,7 +898,7 @@ static bit_t decodeFrame (void) {
                            e_.info   = seqno,
                            e_.info2  = ackup));
 #if LMIC_DEBUG_LEVEL > 1
-	LMIC_DEBUG_PRINTF("%"PRId32": ??ack error ack=%d txCnt=%d\n", os_getTime(), ackup, LMIC.txCnt);
+	LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": ??ack error ack=%d txCnt=%d\n", os_getTime(), ackup, LMIC.txCnt);
 #endif
     }
 
@@ -916,7 +915,7 @@ static bit_t decodeFrame (void) {
         LMIC.dataLen = pend-poff;
     }
 #if LMIC_DEBUG_LEVEL > 0
-    LMIC_DEBUG_PRINTF("%"PRId32": Received downlink, window=%s, port=%d, ack=%d, txrxFlags=%#x\n", os_getTime(), window, port, ackup, LMIC.txrxFlags);
+    LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": Received downlink, window=%s, port=%d, ack=%d, txrxFlags=%#x\n", os_getTime(), window, port, ackup, LMIC.txrxFlags);
 #endif
     return 1;
 }
@@ -965,7 +964,7 @@ static void schedRx12 (ostime_t delay, osjobcb_t func, u1_t dr) {
     // (again note that hsym is half a sumbol time, so no /2 needed)
     LMIC.rxtime = LMIC.txend + delay + PAMBL_SYMS * hsym - LMIC.rxsyms * hsym;
 
-    LMIC_X_DEBUG_PRINTF("%"PRId32": sched Rx12 %"PRId32"\n", os_getTime(), LMIC.rxtime - RX_RAMPUP);
+    LMIC_X_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": sched Rx12 %"LMIC_PRId_ostime_t"\n", os_getTime(), LMIC.rxtime - RX_RAMPUP);
     os_setTimedCallback(&LMIC.osjob, LMIC.rxtime - RX_RAMPUP, func);
 }
 
@@ -1101,7 +1100,7 @@ static bit_t processJoinAccept (void) {
             if( freq ) {
                 LMIC_setupChannel(chidx, freq, 0, -1);
 #if LMIC_DEBUG_LEVEL > 1
-                LMIC_DEBUG_PRINTF("%"PRId32": Setup channel, idx=%d, freq=%"PRIu32"\n", os_getTime(), chidx, freq);
+                LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": Setup channel, idx=%d, freq=%"PRIu32"\n", os_getTime(), chidx, freq);
 #endif
             }
         }
@@ -1715,7 +1714,7 @@ static void startRxPing (xref2osjob_t osjob) {
 // Decide what to do next for the MAC layer of a device
 static void engineUpdate (void) {
 #if LMIC_DEBUG_LEVEL > 0
-    LMIC_DEBUG_PRINTF("%"PRId32": engineUpdate, opmode=0x%x\n", os_getTime(), LMIC.opmode);
+    LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": engineUpdate, opmode=0x%x\n", os_getTime(), LMIC.opmode);
 #endif
     // Check for ongoing state: scan or TX/RX transaction
     if( (LMIC.opmode & (OP_SCAN|OP_TXRXPEND|OP_SHUTDOWN)) != 0 )
@@ -1874,7 +1873,7 @@ static void engineUpdate (void) {
                        e_.eui    = MAIN::CDEV->getEui(),
                        e_.info   = osticks2ms(txbeg-now),
                        e_.info2  = LMIC.seqnoUp-1));
-    LMIC_X_DEBUG_PRINTF("%"PRId32": next engine update in %"PRId32"\n", now, txbeg-TX_RAMPUP);
+    LMIC_X_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": next engine update in %"LMIC_PRId_ostime_t"\n", now, txbeg-TX_RAMPUP);
     os_setTimedCallback(&LMIC.osjob, txbeg-TX_RAMPUP, FUNC_ADDR(runEngineUpdate));
 }
 

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -46,7 +46,7 @@ static void engineUpdate(void);
 static void startScan (void);
 #endif
 
-static inline void initTxrxFlags(const char *func, u1_t mask) {
+static inline void initTxrxFlags(UNUSED_VAR const char *func, u1_t mask) {
 #if LMIC_DEBUG_LEVEL > 1
 	LMIC_DEBUG_PRINTF("%lu: %s txrxFlags %#02x --> %02x\n", os_getTime(), func, LMIC.txrxFlags, mask);
 #endif
@@ -278,7 +278,6 @@ extern inline int isFasterDR (dr_t dr1, dr_t dr2);
 extern inline int isSlowerDR (dr_t dr1, dr_t dr2);
 extern inline dr_t  incDR    (dr_t dr);
 extern inline dr_t  decDR    (dr_t dr);
-extern inline dr_t  assertDR (dr_t dr);
 extern inline dr_t  validDR  (dr_t dr);
 extern inline dr_t  lowerDR  (dr_t dr, u1_t n);
 
@@ -413,7 +412,7 @@ static void txDelay (ostime_t reftime, u1_t secSpan) {
 }
 
 
-void LMICcore_setDrJoin (u1_t reason, u1_t dr) {
+void LMICcore_setDrJoin (UNUSED_VAR u1_t reason, u1_t dr) {
     EV(drChange, INFO, (e_.reason    = reason,
                         e_.deveui    = MAIN::CDEV->getEui(),
                         e_.dr        = dr|DR_PAGE,
@@ -425,7 +424,7 @@ void LMICcore_setDrJoin (u1_t reason, u1_t dr) {
 }
 
 
-static void setDrTxpow (u1_t reason, u1_t dr, s1_t pow) {
+static void setDrTxpow (UNUSED_VAR u1_t reason, u1_t dr, s1_t pow) {
     EV(drChange, INFO, (e_.reason    = reason,
                         e_.deveui    = MAIN::CDEV->getEui(),
                         e_.dr        = dr|DR_PAGE,
@@ -461,7 +460,7 @@ void LMIC_setPingable (u1_t intvExp) {
 
 #endif // !DISABLE_PING
 
-static void runEngineUpdate (xref2osjob_t osjob) {
+static void runEngineUpdate (UNUSED_VAR xref2osjob_t osjob) {
     engineUpdate();
 }
 
@@ -475,7 +474,7 @@ static void reportEvent (ev_t ev) {
 }
 
 
-static void runReset (xref2osjob_t osjob) {
+static void runReset (UNUSED_VAR xref2osjob_t osjob) {
     // Disable session
     LMIC_reset();
 #if !defined(DISABLE_JOIN)
@@ -1019,7 +1018,7 @@ static void txDone (ostime_t delay, osjobcb_t func) {
 
 
 #if !defined(DISABLE_JOIN)
-static void onJoinFailed (xref2osjob_t osjob) {
+static void onJoinFailed (UNUSED_VAR xref2osjob_t osjob) {
     // Notify app - must call LMIC_reset() to stop joining
     // otherwise join procedure continues.
     reportEvent(EV_JOIN_FAILED);
@@ -1072,7 +1071,7 @@ static bit_t processJoinAccept (void) {
     }
     u1_t hdr  = LMIC.frame[0];
     u1_t dlen = LMIC.dataLen;
-    u4_t mic  = os_rlsbf4(&LMIC.frame[dlen-4]); // safe before modified by encrypt!
+    UNUSED_VAR u4_t mic  = os_rlsbf4(&LMIC.frame[dlen-4]); // safe before modified by encrypt!
     if( (dlen != LEN_JA && dlen != LEN_JAEXT)
         || (hdr & (HDR_FTYPE|HDR_MAJOR)) != (HDR_FTYPE_JACC|HDR_MAJOR_V1) ) {
         EV(specCond, ERR, (e_.reason = EV::specCond_t::UNEXPECTED_FRAME,
@@ -1160,7 +1159,7 @@ static bit_t processJoinAccept (void) {
 }
 
 
-static void processRx2Jacc (xref2osjob_t osjob) {
+static void processRx2Jacc (UNUSED_VAR xref2osjob_t osjob) {
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
     }
@@ -1168,24 +1167,24 @@ static void processRx2Jacc (xref2osjob_t osjob) {
 }
 
 
-static void setupRx2Jacc (xref2osjob_t osjob) {
+static void setupRx2Jacc (UNUSED_VAR xref2osjob_t osjob) {
     LMIC.osjob.func = FUNC_ADDR(processRx2Jacc);
     setupRx2();
 }
 
 
-static void processRx1Jacc (xref2osjob_t osjob) {
+static void processRx1Jacc (UNUSED_VAR xref2osjob_t osjob) {
     if( LMIC.dataLen == 0 || !processJoinAccept() )
         schedRx12(DELAY_JACC2_osticks, FUNC_ADDR(setupRx2Jacc), LMIC.dn2Dr);
 }
 
 
-static void setupRx1Jacc (xref2osjob_t osjob) {
+static void setupRx1Jacc (UNUSED_VAR xref2osjob_t osjob) {
     setupRx1(FUNC_ADDR(processRx1Jacc));
 }
 
 
-static void jreqDone (xref2osjob_t osjob) {
+static void jreqDone (UNUSED_VAR xref2osjob_t osjob) {
     txDone(DELAY_JACC1_osticks, FUNC_ADDR(setupRx1Jacc));
 }
 
@@ -1196,11 +1195,11 @@ static void jreqDone (xref2osjob_t osjob) {
 // Fwd decl.
 static bit_t processDnData(void);
 
-static void processRx2DnDataDelay (xref2osjob_t osjob) {
+static void processRx2DnDataDelay (UNUSED_VAR xref2osjob_t osjob) {
     processDnData();
 }
 
-static void processRx2DnData (xref2osjob_t osjob) {
+static void processRx2DnData (UNUSED_VAR xref2osjob_t osjob) {
     if( LMIC.dataLen == 0 ) {
         initTxrxFlags(__func__, 0);  // nothing in 1st/2nd DN slot
         // Delay callback processing to avoid up TX while gateway is txing our missed frame!
@@ -1214,24 +1213,24 @@ static void processRx2DnData (xref2osjob_t osjob) {
 }
 
 
-static void setupRx2DnData (xref2osjob_t osjob) {
+static void setupRx2DnData (UNUSED_VAR xref2osjob_t osjob) {
     LMIC.osjob.func = FUNC_ADDR(processRx2DnData);
     setupRx2();
 }
 
 
-static void processRx1DnData (xref2osjob_t osjob) {
+static void processRx1DnData (UNUSED_VAR xref2osjob_t osjob) {
     if( LMIC.dataLen == 0 || !processDnData() )
         schedRx12(sec2osticks(LMIC.rxDelay +(int)DELAY_EXTDNW2), FUNC_ADDR(setupRx2DnData), LMIC.dn2Dr);
 }
 
 
-static void setupRx1DnData (xref2osjob_t osjob) {
+static void setupRx1DnData (UNUSED_VAR xref2osjob_t osjob) {
     setupRx1(FUNC_ADDR(processRx1DnData));
 }
 
 
-static void updataDone (xref2osjob_t osjob) {
+static void updataDone (UNUSED_VAR xref2osjob_t osjob) {
     txDone(sec2osticks(LMIC.rxDelay), FUNC_ADDR(setupRx1DnData));
 }
 
@@ -1376,7 +1375,7 @@ static void buildDataFrame (void) {
 
 #if !defined(DISABLE_BEACONS)
 // Callback from HAL during scan mode or when job timer expires.
-static void onBcnRx (xref2osjob_t job) {
+static void onBcnRx (UNUSED_VAR xref2osjob_t job) {
     // If we arrive via job timer make sure to put radio to rest.
     os_radio(RADIO_RST);
     os_clearCallback(&LMIC.osjob);
@@ -1496,7 +1495,7 @@ static void buildJoinRequest (u1_t ftype) {
     DO_DEVDB(LMIC.devNonce,devNonce);
 }
 
-static void startJoining (xref2osjob_t osjob) {
+static void startJoining (UNUSED_VAR xref2osjob_t osjob) {
     reportEvent(EV_JOINING);
 }
 
@@ -1529,7 +1528,7 @@ bit_t LMIC_startJoining (void) {
 // ================================================================================
 
 #if !defined(DISABLE_PING)
-static void processPingRx (xref2osjob_t osjob) {
+static void processPingRx (UNUSED_VAR xref2osjob_t osjob) {
     if( LMIC.dataLen != 0 ) {
         initTxrxFlags(__func__, TXRX_PING);
         if( decodeFrame() ) {
@@ -1610,7 +1609,7 @@ static bit_t processDnData (void) {
 
 
 #if !defined(DISABLE_BEACONS)
-static void processBeacon (xref2osjob_t osjob) {
+static void processBeacon (UNUSED_VAR xref2osjob_t osjob) {
     ostime_t lasttx = LMIC.bcninfo.txtime;   // save here - decodeBeacon might overwrite
     u1_t flags = LMIC.bcninfo.flags;
     ev_t ev;
@@ -1671,7 +1670,7 @@ static void processBeacon (xref2osjob_t osjob) {
 }
 
 
-static void startRxBcn (xref2osjob_t osjob) {
+static void startRxBcn (UNUSED_VAR xref2osjob_t osjob) {
     LMIC.osjob.func = FUNC_ADDR(processBeacon);
     os_radio(RADIO_RX);
 }
@@ -1679,7 +1678,7 @@ static void startRxBcn (xref2osjob_t osjob) {
 
 
 #if !defined(DISABLE_PING)
-static void startRxPing (xref2osjob_t osjob) {
+static void startRxPing (UNUSED_VAR xref2osjob_t osjob) {
     LMIC.osjob.func = FUNC_ADDR(processPingRx);
     os_radio(RADIO_RX);
 }

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -275,28 +275,6 @@ ostime_t calcAirTime (rps_t rps, u1_t plen) {
     return (((ostime_t)tmp << sfx) * OSTICKS_PER_SEC + div/2) / div;
 }
 
-extern inline rps_t updr2rps (dr_t dr);
-extern inline rps_t dndr2rps (dr_t dr);
-extern inline int isFasterDR (dr_t dr1, dr_t dr2);
-extern inline int isSlowerDR (dr_t dr1, dr_t dr2);
-extern inline dr_t  incDR    (dr_t dr);
-extern inline dr_t  decDR    (dr_t dr);
-extern inline dr_t  validDR  (dr_t dr);
-extern inline dr_t  lowerDR  (dr_t dr, u1_t n);
-
-extern inline sf_t  getSf    (rps_t params);
-extern inline rps_t setSf    (rps_t params, sf_t sf);
-extern inline bw_t  getBw    (rps_t params);
-extern inline rps_t setBw    (rps_t params, bw_t cr);
-extern inline cr_t  getCr    (rps_t params);
-extern inline rps_t setCr    (rps_t params, cr_t cr);
-extern inline int   getNocrc (rps_t params);
-extern inline rps_t setNocrc (rps_t params, int nocrc);
-extern inline int   getIh    (rps_t params);
-extern inline rps_t setIh    (rps_t params, int ih);
-extern inline rps_t makeRps  (sf_t sf, bw_t bw, cr_t cr, int ih, int nocrc);
-extern inline int   sameSfBw (rps_t r1, rps_t r2);
-
 // END LORA
 // ================================================================================
 

--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -31,6 +31,7 @@
 //! \file
 #define LMIC_DR_LEGACY 0
 #include "lmic_bandplan.h"
+#include "inttypes.h"
 
 #if defined(DISABLE_BEACONS) && !defined(DISABLE_PING)
 #error Ping needs beacon tracking
@@ -48,7 +49,7 @@ static void startScan (void);
 
 static inline void initTxrxFlags(UNUSED_VAR const char *func, u1_t mask) {
 #if LMIC_DEBUG_LEVEL > 1
-	LMIC_DEBUG_PRINTF("%lu: %s txrxFlags %#02x --> %02x\n", os_getTime(), func, LMIC.txrxFlags, mask);
+	LMIC_DEBUG_PRINTF("%"PRId32": %s txrxFlags %#02x --> %02x\n", os_getTime(), func, LMIC.txrxFlags, mask);
 #endif
 	LMIC.txrxFlags = mask;
 }
@@ -593,7 +594,7 @@ scan_mac_cmds(
             // of contiguous commands (whatever that means), and ignore the
             // data rate, NbTrans (uprpt) and txPow until the last one.
 #if LMIC_DEBUG_LEVEL > 0
-            LMIC_DEBUG_PRINTF("%lu: LinkAdrReq: p1:%02x chmap:%04x chpage:%02x uprt:%02x ans:%02x\n",
+            LMIC_DEBUG_PRINTF("%"PRId32": LinkAdrReq: p1:%02x chmap:%04x chpage:%02x uprt:%02x ans:%02x\n",
 		os_getTime(), p1, chmap, chpage, uprpt, LMIC.ladrAns
 		);
 #endif /* LMIC_DEBUG_LEVEL */
@@ -756,7 +757,7 @@ static bit_t decodeFrame (void) {
                             e_.info2  = hdr + (dlen<<8)));
       norx:
 #if LMIC_DEBUG_LEVEL > 0
-        LMIC_DEBUG_PRINTF("%lu: Invalid downlink, window=%s\n", os_getTime(), window);
+        LMIC_DEBUG_PRINTF("%"PRId32": Invalid downlink, window=%s\n", os_getTime(), window);
 #endif
         LMIC.dataLen = 0;
         return 0;
@@ -848,7 +849,7 @@ static bit_t decodeFrame (void) {
 
 #if LMIC_DEBUG_LEVEL > 0
     // Process OPTS
-    LMIC_DEBUG_PRINTF("%lu: process options (olen=%#x)\n", os_getTime(), olen);
+    LMIC_DEBUG_PRINTF("%"PRId32": process options (olen=%#x)\n", os_getTime(), olen);
 #endif
 
     xref2u1_t opts = &d[OFF_DAT_OPTS];
@@ -867,13 +868,13 @@ static bit_t decodeFrame (void) {
             if (port == 0) {
                 // this is a mac command. scan the options.
 #if LMIC_DEBUG_LEVEL > 0
-                LMIC_DEBUG_PRINTF("%lu: process mac commands for port 0 (olen=%#x)\n", os_getTime(), pend-poff);
+                LMIC_DEBUG_PRINTF("%"PRId32": process mac commands for port 0 (olen=%#x)\n", os_getTime(), pend-poff);
 #endif
                 int optendindex = scan_mac_cmds(d+poff, pend-poff);
                 if (optendindex != pend-poff) {
 #if LMIC_DEBUG_LEVEL > 0
                     LMIC_DEBUG_PRINTF(
-                        "%lu: error processing mac commands for port 0 "
+                        "%"PRId32": error processing mac commands for port 0 "
                         "(len=%#x, optendindex=%#x)\n",
                         os_getTime(), pend-poff, optendindex
                         );
@@ -910,7 +911,7 @@ static bit_t decodeFrame (void) {
                            e_.info   = seqno,
                            e_.info2  = ackup));
 #if LMIC_DEBUG_LEVEL > 1
-	LMIC_DEBUG_PRINTF("%lu: ??ack error ack=%d txCnt=%d\n", os_getTime(), ackup, LMIC.txCnt);
+	LMIC_DEBUG_PRINTF("%"PRId32": ??ack error ack=%d txCnt=%d\n", os_getTime(), ackup, LMIC.txCnt);
 #endif
     }
 
@@ -927,7 +928,7 @@ static bit_t decodeFrame (void) {
         LMIC.dataLen = pend-poff;
     }
 #if LMIC_DEBUG_LEVEL > 0
-    LMIC_DEBUG_PRINTF("%lu: Received downlink, window=%s, port=%d, ack=%d, txrxFlags=%#x\n", os_getTime(), window, port, ackup, LMIC.txrxFlags);
+    LMIC_DEBUG_PRINTF("%"PRId32": Received downlink, window=%s, port=%d, ack=%d, txrxFlags=%#x\n", os_getTime(), window, port, ackup, LMIC.txrxFlags);
 #endif
     return 1;
 }
@@ -976,7 +977,7 @@ static void schedRx12 (ostime_t delay, osjobcb_t func, u1_t dr) {
     // (again note that hsym is half a sumbol time, so no /2 needed)
     LMIC.rxtime = LMIC.txend + delay + PAMBL_SYMS * hsym - LMIC.rxsyms * hsym;
 
-    LMIC_X_DEBUG_PRINTF("%lu: sched Rx12 %lu\n", os_getTime(), LMIC.rxtime - RX_RAMPUP);
+    LMIC_X_DEBUG_PRINTF("%"PRId32": sched Rx12 %"PRId32"\n", os_getTime(), LMIC.rxtime - RX_RAMPUP);
     os_setTimedCallback(&LMIC.osjob, LMIC.rxtime - RX_RAMPUP, func);
 }
 
@@ -1108,7 +1109,7 @@ static bit_t processJoinAccept (void) {
             if( freq ) {
                 LMIC_setupChannel(chidx, freq, 0, -1);
 #if LMIC_DEBUG_LEVEL > 1
-                LMIC_DEBUG_PRINTF("%lu: Setup channel, idx=%d, freq=%lu\n", os_getTime(), chidx, (unsigned long)freq);
+                LMIC_DEBUG_PRINTF("%"PRId32": Setup channel, idx=%d, freq=%"PRIu32"\n", os_getTime(), chidx, freq);
 #endif
             }
         }
@@ -1688,7 +1689,7 @@ static void startRxPing (UNUSED_VAR xref2osjob_t osjob) {
 // Decide what to do next for the MAC layer of a device
 static void engineUpdate (void) {
 #if LMIC_DEBUG_LEVEL > 0
-    LMIC_DEBUG_PRINTF("%lu: engineUpdate, opmode=0x%x\n", os_getTime(), LMIC.opmode);
+    LMIC_DEBUG_PRINTF("%"PRId32": engineUpdate, opmode=0x%x\n", os_getTime(), LMIC.opmode);
 #endif
     // Check for ongoing state: scan or TX/RX transaction
     if( (LMIC.opmode & (OP_SCAN|OP_TXRXPEND|OP_SHUTDOWN)) != 0 )
@@ -1847,7 +1848,7 @@ static void engineUpdate (void) {
                        e_.eui    = MAIN::CDEV->getEui(),
                        e_.info   = osticks2ms(txbeg-now),
                        e_.info2  = LMIC.seqnoUp-1));
-    LMIC_X_DEBUG_PRINTF("%lu: next engine update in %lu\n", now, txbeg-TX_RAMPUP);
+    LMIC_X_DEBUG_PRINTF("%"PRId32": next engine update in %"PRId32"\n", now, txbeg-TX_RAMPUP);
     os_setTimedCallback(&LMIC.osjob, txbeg-TX_RAMPUP, FUNC_ADDR(runEngineUpdate));
 }
 

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -75,12 +75,12 @@ static CONST_TABLE(u1_t, maxFrameLens_dwell1)[] = {
 };
 
 static uint8_t 
-LMICas923_getUplinkDwellBit(uint8_t mcmd_txparam) {
+LMICas923_getUplinkDwellBit(UNUSED_VAR uint8_t mcmd_txparam) {
         return (LMIC.txParam & MCMD_TxParam_TxDWELL_MASK) != 0; 
 }
 
 static uint8_t 
-LMICas923_getDownlinkDwellBit(uint8_t mcmd_txparam) {
+LMICas923_getDownlinkDwellBit(UNUSED_VAR uint8_t mcmd_txparam) {
         return (LMIC.txParam & MCMD_TxParam_RxDWELL_MASK) != 0; 
 }
 
@@ -163,7 +163,7 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
 };
 
 // as923 ignores join, becuase the channel setup is the same either way.
-void LMICas923_initDefaultChannels(bit_t join) {
+void LMICas923_initDefaultChannels(UNUSED_VAR bit_t join) {
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
         os_clearMem(&LMIC.channelDrMap, sizeof(LMIC.channelDrMap));
         os_clearMem(&LMIC.bands, sizeof(LMIC.bands));

--- a/src/lmic/lmic_as923.c
+++ b/src/lmic/lmic_as923.c
@@ -75,12 +75,16 @@ static CONST_TABLE(u1_t, maxFrameLens_dwell1)[] = {
 };
 
 static uint8_t 
-LMICas923_getUplinkDwellBit(UNUSED_VAR uint8_t mcmd_txparam) {
+LMICas923_getUplinkDwellBit(uint8_t mcmd_txparam) {
+        LMIC_API_PARAMETER(mcmd_txparam);
+
         return (LMIC.txParam & MCMD_TxParam_TxDWELL_MASK) != 0; 
 }
 
 static uint8_t 
-LMICas923_getDownlinkDwellBit(UNUSED_VAR uint8_t mcmd_txparam) {
+LMICas923_getDownlinkDwellBit(uint8_t mcmd_txparam) {
+        LMIC_API_PARAMETER(mcmd_txparam);
+
         return (LMIC.txParam & MCMD_TxParam_RxDWELL_MASK) != 0; 
 }
 
@@ -163,7 +167,9 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
 };
 
 // as923 ignores join, becuase the channel setup is the same either way.
-void LMICas923_initDefaultChannels(UNUSED_VAR bit_t join) {
+void LMICas923_initDefaultChannels(bit_t join) {
+        LMIC_API_PARAMETER(join);
+
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
         os_clearMem(&LMIC.channelDrMap, sizeof(LMIC.channelDrMap));
         os_clearMem(&LMIC.bands, sizeof(LMIC.bands));

--- a/src/lmic/lmic_au921.c
+++ b/src/lmic/lmic_au921.c
@@ -100,7 +100,7 @@ u4_t LMICau921_convFreq(xref2cu1_t ptr) {
 }
 
 // au921: no support for xchannels.
-bit_t LMIC_setupChannel(u1_t chidx, u4_t freq, u2_t drmap, s1_t band) {
+bit_t LMIC_setupChannel(UNUSED_VAR u1_t chidx, UNUSED_VAR u4_t freq, UNUSED_VAR u2_t drmap, UNUSED_VAR s1_t band) {
         return 0; // all channels are hardwired.
 }
 

--- a/src/lmic/lmic_au921.c
+++ b/src/lmic/lmic_au921.c
@@ -100,7 +100,12 @@ u4_t LMICau921_convFreq(xref2cu1_t ptr) {
 }
 
 // au921: no support for xchannels.
-bit_t LMIC_setupChannel(UNUSED_VAR u1_t chidx, UNUSED_VAR u4_t freq, UNUSED_VAR u2_t drmap, UNUSED_VAR s1_t band) {
+bit_t LMIC_setupChannel(u1_t chidx, u4_t freq, u2_t drmap, s1_t band) {
+        LMIC_API_PARAMETER(chidx);
+        LMIC_API_PARAMETER(freq);
+        LMIC_API_PARAMETER(drmap);
+        LMIC_API_PARAMETER(band);
+
         return 0; // all channels are hardwired.
 }
 

--- a/src/lmic/lmic_eu_like.c
+++ b/src/lmic/lmic_eu_like.c
@@ -32,10 +32,12 @@
 
 #if CFG_LMIC_EU_like
 
-void  LMIC_enableSubBand(UNUSED_VAR u1_t band) {
+void  LMIC_enableSubBand(u1_t band) {
+        LMIC_API_PARAMETER(band);
 }
 
-void  LMIC_disableSubBand(UNUSED_VAR u1_t band) {
+void  LMIC_disableSubBand(u1_t band) {
+        LMIC_API_PARAMETER(band);
 }
 
 void LMIC_disableChannel(u1_t channel) {
@@ -45,7 +47,8 @@ void LMIC_disableChannel(u1_t channel) {
 }
 
 // this is a no-op provided for compatibilty
-void LMIC_enableChannel(UNUSED_VAR u1_t channel) {
+void LMIC_enableChannel(u1_t channel) {
+        LMIC_API_PARAMETER(channel);
 }
 
 u1_t LMICeulike_mapChannels(u1_t chpage, u2_t chmap) {

--- a/src/lmic/lmic_eu_like.c
+++ b/src/lmic/lmic_eu_like.c
@@ -32,10 +32,10 @@
 
 #if CFG_LMIC_EU_like
 
-void  LMIC_enableSubBand(u1_t band) {
+void  LMIC_enableSubBand(UNUSED_VAR u1_t band) {
 }
 
-void  LMIC_disableSubBand(u1_t band) {
+void  LMIC_disableSubBand(UNUSED_VAR u1_t band) {
 }
 
 void LMIC_disableChannel(u1_t channel) {
@@ -45,7 +45,7 @@ void LMIC_disableChannel(u1_t channel) {
 }
 
 // this is a no-op provided for compatibilty
-void LMIC_enableChannel(u1_t channel) {
+void LMIC_enableChannel(UNUSED_VAR u1_t channel) {
 }
 
 u1_t LMICeulike_mapChannels(u1_t chpage, u2_t chmap) {

--- a/src/lmic/lmic_in866.c
+++ b/src/lmic/lmic_in866.c
@@ -94,7 +94,7 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
 };
 
 // india ignores join, becuase the channel setup is the same either way.
-void LMICin866_initDefaultChannels(bit_t join) {
+void LMICin866_initDefaultChannels(UNUSED_VAR bit_t join) {
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
         os_clearMem(&LMIC.channelDrMap, sizeof(LMIC.channelDrMap));
         os_clearMem(&LMIC.bands, sizeof(LMIC.bands));

--- a/src/lmic/lmic_in866.c
+++ b/src/lmic/lmic_in866.c
@@ -94,7 +94,9 @@ static CONST_TABLE(u4_t, iniChannelFreq)[NUM_DEFAULT_CHANNELS] = {
 };
 
 // india ignores join, becuase the channel setup is the same either way.
-void LMICin866_initDefaultChannels(UNUSED_VAR bit_t join) {
+void LMICin866_initDefaultChannels(bit_t join) {
+        LMIC_API_PARAMETER(join);
+
         os_clearMem(&LMIC.channelFreq, sizeof(LMIC.channelFreq));
         os_clearMem(&LMIC.channelDrMap, sizeof(LMIC.channelDrMap));
         os_clearMem(&LMIC.bands, sizeof(LMIC.bands));

--- a/src/lmic/lmic_us915.c
+++ b/src/lmic/lmic_us915.c
@@ -86,7 +86,7 @@ u4_t LMICus915_convFreq(xref2cu1_t ptr) {
         return freq;
 }
 
-bit_t LMIC_setupChannel(u1_t chidx, u4_t freq, u2_t drmap, s1_t band) {
+bit_t LMIC_setupChannel(u1_t chidx, u4_t freq, u2_t drmap, UNUSED_VAR s1_t band) {
         if (chidx < 72 || chidx >= 72 + MAX_XCHANNELS)
                 return 0; // channels 0..71 are hardwired
         LMIC.xchFreq[chidx - 72] = freq;

--- a/src/lmic/lmic_us915.c
+++ b/src/lmic/lmic_us915.c
@@ -86,7 +86,9 @@ u4_t LMICus915_convFreq(xref2cu1_t ptr) {
         return freq;
 }
 
-bit_t LMIC_setupChannel(u1_t chidx, u4_t freq, u2_t drmap, UNUSED_VAR s1_t band) {
+bit_t LMIC_setupChannel(u1_t chidx, u4_t freq, u2_t drmap, s1_t band) {
+        LMIC_API_PARAMETER(band);
+
         if (chidx < 72 || chidx >= 72 + MAX_XCHANNELS)
                 return 0; // channels 0..71 are hardwired
         LMIC.xchFreq[chidx - 72] = freq;

--- a/src/lmic/lmic_us_like.c
+++ b/src/lmic/lmic_us_like.c
@@ -70,13 +70,19 @@ static void setNextChannel(uint start, uint end, uint count) {
 
 
 
-bit_t LMIC_setupBand(UNUSED_VAR u1_t bandidx, UNUSED_VAR s1_t txpow, UNUSED_VAR u2_t txcap) {
+bit_t LMIC_setupBand(u1_t bandidx, s1_t txpow, u2_t txcap) {
+        LMIC_API_PARAMETER(bandidx);
+        LMIC_API_PARAMETER(txpow);
+        LMIC_API_PARAMETER(txcap);
+
         // nothing; just succeed.
 	return 1;
 }
 
 
-void LMICuslike_initDefaultChannels(UNUSED_VAR bit_t fJoin) {
+void LMICuslike_initDefaultChannels(bit_t fJoin) {
+        LMIC_API_PARAMETER(fJoin);
+
         // things work the same for join as normal.
         for (u1_t i = 0; i<4; i++)
                 LMIC.channelMap[i] = 0xFFFF;

--- a/src/lmic/lmic_us_like.c
+++ b/src/lmic/lmic_us_like.c
@@ -70,13 +70,13 @@ static void setNextChannel(uint start, uint end, uint count) {
 
 
 
-bit_t LMIC_setupBand(u1_t bandidx, s1_t txpow, u2_t txcap) {
+bit_t LMIC_setupBand(UNUSED_VAR u1_t bandidx, UNUSED_VAR s1_t txpow, UNUSED_VAR u2_t txcap) {
         // nothing; just succeed.
 	return 1;
 }
 
 
-void LMICuslike_initDefaultChannels(bit_t fJoin) {
+void LMICuslike_initDefaultChannels(UNUSED_VAR bit_t fJoin) {
         // things work the same for join as normal.
         for (u1_t i = 0; i<4; i++)
                 LMIC.channelMap[i] = 0xFFFF;

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -583,32 +583,32 @@ typedef u4_t devaddr_t;
 // RX quality (device)
 enum { RSSI_OFF=64, SNR_SCALEUP=4 };
 
-inline sf_t  getSf   (rps_t params)            { return   (sf_t)(params &  0x7); }
-inline rps_t setSf   (rps_t params, sf_t sf)   { return (rps_t)((params & ~0x7) | sf); }
-inline bw_t  getBw   (rps_t params)            { return  (bw_t)((params >> 3) & 0x3); }
-inline rps_t setBw   (rps_t params, bw_t cr)   { return (rps_t)((params & ~0x18) | (cr<<3)); }
-inline cr_t  getCr   (rps_t params)            { return  (cr_t)((params >> 5) & 0x3); }
-inline rps_t setCr   (rps_t params, cr_t cr)   { return (rps_t)((params & ~0x60) | (cr<<5)); }
-inline int   getNocrc(rps_t params)            { return        ((params >> 7) & 0x1); }
-inline rps_t setNocrc(rps_t params, int nocrc) { return (rps_t)((params & ~0x80) | (nocrc<<7)); }
-inline int   getIh   (rps_t params)            { return        ((params >> 8) & 0xFF); }
-inline rps_t setIh   (rps_t params, int ih)    { return (rps_t)((params & ~0xFF00) | (ih<<8)); }
-inline rps_t makeRps (sf_t sf, bw_t bw, cr_t cr, int ih, int nocrc) {
+static inline sf_t  getSf   (rps_t params)            { return   (sf_t)(params &  0x7); }
+static inline rps_t setSf   (rps_t params, sf_t sf)   { return (rps_t)((params & ~0x7) | sf); }
+static inline bw_t  getBw   (rps_t params)            { return  (bw_t)((params >> 3) & 0x3); }
+static inline rps_t setBw   (rps_t params, bw_t cr)   { return (rps_t)((params & ~0x18) | (cr<<3)); }
+static inline cr_t  getCr   (rps_t params)            { return  (cr_t)((params >> 5) & 0x3); }
+static inline rps_t setCr   (rps_t params, cr_t cr)   { return (rps_t)((params & ~0x60) | (cr<<5)); }
+static inline int   getNocrc(rps_t params)            { return        ((params >> 7) & 0x1); }
+static inline rps_t setNocrc(rps_t params, int nocrc) { return (rps_t)((params & ~0x80) | (nocrc<<7)); }
+static inline int   getIh   (rps_t params)            { return        ((params >> 8) & 0xFF); }
+static inline rps_t setIh   (rps_t params, int ih)    { return (rps_t)((params & ~0xFF00) | (ih<<8)); }
+static inline rps_t makeRps (sf_t sf, bw_t bw, cr_t cr, int ih, int nocrc) {
     return sf | (bw<<3) | (cr<<5) | (nocrc?(1<<7):0) | ((ih&0xFF)<<8);
 }
 #define MAKERPS(sf,bw,cr,ih,nocrc) ((rps_t)((sf) | ((bw)<<3) | ((cr)<<5) | ((nocrc)?(1<<7):0) | ((ih&0xFF)<<8)))
 // Two frames with params r1/r2 would interfere on air: same SFx + BWx
-inline int sameSfBw(rps_t r1, rps_t r2) { return ((r1^r2)&0x1F) == 0; }
+static inline int sameSfBw(rps_t r1, rps_t r2) { return ((r1^r2)&0x1F) == 0; }
 
 extern CONST_TABLE(u1_t, _DR2RPS_CRC)[];
-inline rps_t updr2rps (dr_t dr) { return (rps_t)TABLE_GET_U1(_DR2RPS_CRC, dr+1); }
-inline rps_t dndr2rps (dr_t dr) { return setNocrc(updr2rps(dr),1); }
-inline int isFasterDR (dr_t dr1, dr_t dr2) { return dr1 > dr2; }
-inline int isSlowerDR (dr_t dr1, dr_t dr2) { return dr1 < dr2; }
-inline dr_t  incDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+2)==ILLEGAL_RPS ? dr : (dr_t)(dr+1); } // increase data rate
-inline dr_t  decDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr  )==ILLEGAL_RPS ? dr : (dr_t)(dr-1); } // decrease data rate
-inline bit_t validDR  (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+1)!=ILLEGAL_RPS; } // in range
-inline dr_t  lowerDR  (dr_t dr, u1_t n) { while(n--){dr=decDR(dr);} return dr; } // decrease data rate by n steps
+static inline rps_t updr2rps (dr_t dr) { return (rps_t)TABLE_GET_U1(_DR2RPS_CRC, dr+1); }
+static inline rps_t dndr2rps (dr_t dr) { return setNocrc(updr2rps(dr),1); }
+static inline int isFasterDR (dr_t dr1, dr_t dr2) { return dr1 > dr2; }
+static inline int isSlowerDR (dr_t dr1, dr_t dr2) { return dr1 < dr2; }
+static inline dr_t  incDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+2)==ILLEGAL_RPS ? dr : (dr_t)(dr+1); } // increase data rate
+static inline dr_t  decDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr  )==ILLEGAL_RPS ? dr : (dr_t)(dr-1); } // decrease data rate
+static inline bit_t validDR  (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+1)!=ILLEGAL_RPS; } // in range
+static inline dr_t  lowerDR  (dr_t dr, u1_t n) { while(n--){dr=decDR(dr);} return dr; } // decrease data rate by n steps
 
 //
 // BEG: Keep in sync with lorabase.hpp

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -607,7 +607,6 @@ inline int isFasterDR (dr_t dr1, dr_t dr2) { return dr1 > dr2; }
 inline int isSlowerDR (dr_t dr1, dr_t dr2) { return dr1 < dr2; }
 inline dr_t  incDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+2)==ILLEGAL_RPS ? dr : (dr_t)(dr+1); } // increase data rate
 inline dr_t  decDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr  )==ILLEGAL_RPS ? dr : (dr_t)(dr-1); } // decrease data rate
-inline dr_t  assertDR (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+1)==ILLEGAL_RPS ? DR_DFLTMIN : dr; }   // force into a valid DR
 inline bit_t validDR  (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+1)!=ILLEGAL_RPS; } // in range
 inline dr_t  lowerDR  (dr_t dr, u1_t n) { while(n--){dr=decDR(dr);} return dr; } // decrease data rate by n steps
 

--- a/src/lmic/lorabase.h
+++ b/src/lmic/lorabase.h
@@ -607,6 +607,7 @@ static inline int isFasterDR (dr_t dr1, dr_t dr2) { return dr1 > dr2; }
 static inline int isSlowerDR (dr_t dr1, dr_t dr2) { return dr1 < dr2; }
 static inline dr_t  incDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+2)==ILLEGAL_RPS ? dr : (dr_t)(dr+1); } // increase data rate
 static inline dr_t  decDR    (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr  )==ILLEGAL_RPS ? dr : (dr_t)(dr-1); } // decrease data rate
+static inline dr_t  assertDR (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+1)==ILLEGAL_RPS ? DR_DFLTMIN : dr; }   // force into a valid DR
 static inline bit_t validDR  (dr_t dr) { return TABLE_GET_U1(_DR2RPS_CRC, dr+1)!=ILLEGAL_RPS; } // in range
 static inline dr_t  lowerDR  (dr_t dr, u1_t n) { while(n--){dr=decDR(dr);} return dr; } // decrease data rate by n steps
 

--- a/src/lmic/oslmic.c
+++ b/src/lmic/oslmic.c
@@ -71,7 +71,7 @@ static int unlinkjob (osjob_t** pnext, osjob_t* job) {
 // clear scheduled job
 void os_clearCallback (osjob_t* job) {
     hal_disableIRQs();
-    unlinkjob(&OS.scheduledjobs, job) || unlinkjob(&OS.runnablejobs, job);
+    UNUSED_VAR int res = unlinkjob(&OS.scheduledjobs, job) || unlinkjob(&OS.runnablejobs, job);
     hal_enableIRQs();
 }
 

--- a/src/lmic/oslmic.c
+++ b/src/lmic/oslmic.c
@@ -71,7 +71,11 @@ static int unlinkjob (osjob_t** pnext, osjob_t* job) {
 // clear scheduled job
 void os_clearCallback (osjob_t* job) {
     hal_disableIRQs();
-    UNUSED_VAR int res = unlinkjob(&OS.scheduledjobs, job) || unlinkjob(&OS.runnablejobs, job);
+
+    // if it's not in the scheduled jobs, look in the runnable...
+    if (! unlinkjob(&OS.scheduledjobs, job))
+        unlinkjob(&OS.runnablejobs, job);
+
     hal_enableIRQs();
 }
 

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -82,6 +82,7 @@ typedef              s4_t  ostime_t;
 #define TYPEDEF_xref2osjob_t   typedef       osjob_t* xref2osjob_t
 
 #define SIZEOFEXPR(x) sizeof(x)
+#define UNUSED_VAR __attribute__((unused))
 
 #define ON_LMIC_EVENT(ev)  onEvent(ev)
 #define DECL_ON_LMIC_EVENT void onEvent(ev_t e)

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -75,6 +75,14 @@ typedef        const u1_t* xref2cu1_t;
 typedef              u1_t* xref2u1_t;
 typedef              s4_t  ostime_t;
 
+// int32_t == s4_t is long on some platforms; and someday
+// we will want 64-bit ostime_t. So, we will use a macro for the
+// print formatting of ostime_t.
+#ifndef LMIC_PRId_ostime_t
+# include <inttypes.h>
+# define LMIC_PRId_ostime_t	PRId32
+#endif
+
 #define TYPEDEF_xref2rps_t     typedef         rps_t* xref2rps_t
 #define TYPEDEF_xref2rxsched_t typedef     rxsched_t* xref2rxsched_t
 #define TYPEDEF_xref2chnldef_t typedef     chnldef_t* xref2chnldef_t

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -82,7 +82,105 @@ typedef              s4_t  ostime_t;
 #define TYPEDEF_xref2osjob_t   typedef       osjob_t* xref2osjob_t
 
 #define SIZEOFEXPR(x) sizeof(x)
-#define UNUSED_VAR __attribute__((unused))
+
+//----------------------------------------------------------------------------
+// Annotations to avoid various "unused" warnings. These must appear as a
+// statement in the function body; the macro annotates the variable to quiet
+// compiler warnings.  The way this is done is compiler-specific, and so these
+// definitions are fall-backs, which might be overridden.
+//
+// Although these are all similar, we don't want extra macro expansions,
+// so we define each one explicitly rather than relying on a common macro.
+//----------------------------------------------------------------------------
+
+// signal that a parameter is intentionally unused.
+#ifndef LMIC_UNREFERENCED_PARAMETER
+# define LMIC_UNREFERENCED_PARAMETER(v)      do { (void) (v); } while (0)
+#endif
+
+// an API parameter is a parameter that is required by an API definition, but
+// happens to be unreferenced in this implementation. This is a stronger
+// assertion than LMIC_UNREFERENCED_PARAMETER(): this parameter is here
+// becuase of an API contract, but we have no use for it in this function.
+#ifndef LMIC_API_PARAMETER
+# define LMIC_API_PARAMETER(v)               do { (void) (v); } while (0)
+#endif
+
+// an intentionally-unreferenced variable.
+#ifndef LMIC_UNREFERENCED_VARIABLE
+# define LMIC_UNREFERENCED_VARIABLE(v)       do { (void) (v); } while (0)
+#endif
+
+// we have three (!) debug levels (LMIC_DEBUG_LEVEL > 0, LMIC_DEBUG_LEVEL > 1,
+// and LMIC_X_DEBUG_LEVEL > 0. In each case we might have parameters or
+// or varables that are only refereneced at the target debug level.
+
+// Parameter referenced only if debugging at level > 0.
+#ifndef LMIC_DEBUG1_PARAMETER
+# if LMIC_DEBUG_LEVEL > 0
+#  define LMIC_DEBUG1_PARAMETER(v)           do { ; } while (0)
+# else
+#  define LMIC_DEBUG1_PARAMETER(v)           do { (void) (v); } while (0)
+# endif
+#endif
+
+// variable referenced only if debugging at level > 0
+#ifndef LMIC_DEBUG1_VARIABLE
+# if LMIC_DEBUG_LEVEL > 0
+#  define LMIC_DEBUG1_VARIABLE(v)            do { ; } while (0)
+# else
+#  define LMIC_DEBUG1_VARIABLE(v)            do { (void) (v); } while (0)
+# endif
+#endif
+
+// parameter referenced only if debugging at level > 1
+#ifndef LMIC_DEBUG2_PARAMETER
+# if LMIC_DEBUG_LEVEL > 1
+#  define LMIC_DEBUG2_PARAMETER(v)           do { ; } while (0)
+# else
+#  define LMIC_DEBUG2_PARAMETER(v)           do { (void) (v); } while (0)
+# endif
+#endif
+
+// variable referenced only if debugging at level > 1
+#ifndef LMIC_DEBUG2_VARIABLE
+# if LMIC_DEBUG_LEVEL > 1
+#  define LMIC_DEBUG2_VARIABLE(v)            do { ; } while (0)
+# else
+#  define LMIC_DEBUG2_VARIABLE(v)            do { (void) (v); } while (0)
+# endif
+#endif
+
+// parameter referenced only if LMIC_X_DEBUG_LEVEL > 0
+#ifndef LMIC_X_DEBUG_PARAMETER
+# if LMIC_X_DEBUG_LEVEL > 0
+#  define LMIC_X_DEBUG_PARAMETER(v)           do { ; } while (0)
+# else
+#  define LMIC_X_DEBUG_PARAMETER(v)           do { (void) (v); } while (0)
+# endif
+#endif
+
+// variable referenced only if LMIC_X_DEBUG_LEVEL > 0
+#ifndef LMIC_X_DEBUG_VARIABLE
+# if LMIC_X_DEBUG_LEVEL > 0
+#  define LMIC_X_DEBUG_VARIABLE(v)            do { ; } while (0)
+# else
+#  define LMIC_X_DEBUG_VARIABLE(v)            do { (void) (v); } while (0)
+# endif
+#endif
+
+// parameter referenced only if EV() macro is enabled (which it never is)
+// TODO(tmm@mcci.com) take out the EV() framework as it reuqires C++, and
+// this code is really C-99 to its bones.
+#ifndef LMIC_EV_PARAMETER
+# define LMIC_EV_PARAMETER(v)                 do { (void) (v); } while (0)
+#endif
+
+// variable referenced only if EV() macro is defined.
+#ifndef LMIC_EV_VARIABLE
+# define LMIC_EV_VARIABLE(v)                  do { (void) (v); } while (0)
+#endif
+
 
 #define ON_LMIC_EVENT(ev)  onEvent(ev)
 #define DECL_ON_LMIC_EVENT void onEvent(ev_t e)
@@ -259,7 +357,7 @@ u2_t os_crc16 (xref2cu1_t d, uint len);
     // progmem using pgm_read_xx, or accesses memory directly when the
     // index is a constant so gcc can optimize it away;
     #define TABLE_GETTER(postfix, type, pgm_type) \
-        inline type table_get ## postfix(const type *table, size_t index) { \
+        static inline type table_get ## postfix(const type *table, size_t index) { \
             if (__builtin_constant_p(table[index])) \
                 return table[index]; \
             return pgm_read_ ## pgm_type(&table[index]); \
@@ -279,13 +377,13 @@ u2_t os_crc16 (xref2cu1_t d, uint len);
     // For AVR, store constants in PROGMEM, saving on RAM usage
     #define CONST_TABLE(type, name) const type PROGMEM RESOLVE_TABLE(name)
 #else
-    inline u1_t table_get_u1(const u1_t *table, size_t index) { return table[index]; }
-    inline s1_t table_get_s1(const s1_t *table, size_t index) { return table[index]; }
-    inline u2_t table_get_u2(const u2_t *table, size_t index) { return table[index]; }
-    inline s2_t table_get_s2(const s2_t *table, size_t index) { return table[index]; }
-    inline u4_t table_get_u4(const u4_t *table, size_t index) { return table[index]; }
-    inline s4_t table_get_s4(const s4_t *table, size_t index) { return table[index]; }
-    inline ostime_t table_get_ostime(const ostime_t *table, size_t index) { return table[index]; }
+    static inline u1_t table_get_u1(const u1_t *table, size_t index) { return table[index]; }
+    static inline s1_t table_get_s1(const s1_t *table, size_t index) { return table[index]; }
+    static inline u2_t table_get_u2(const u2_t *table, size_t index) { return table[index]; }
+    static inline s2_t table_get_s2(const s2_t *table, size_t index) { return table[index]; }
+    static inline u4_t table_get_u4(const u4_t *table, size_t index) { return table[index]; }
+    static inline s4_t table_get_s4(const s4_t *table, size_t index) { return table[index]; }
+    static inline ostime_t table_get_ostime(const ostime_t *table, size_t index) { return table[index]; }
 
     // Declare a table
     #define CONST_TABLE(type, name) const type RESOLVE_TABLE(name)

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -28,7 +28,6 @@
 
 #define LMIC_DR_LEGACY 0
 
-#include <inttypes.h>
 #include "lmic.h"
 
 // ----------------------------------------
@@ -550,7 +549,7 @@ static void txlora () {
     u1_t sf = getSf(LMIC.rps) + 6; // 1 == SF7
     u1_t bw = getBw(LMIC.rps);
     u1_t cr = getCr(LMIC.rps);
-    LMIC_DEBUG_PRINTF("%"PRId32": TXMODE, freq=%"PRIu32", len=%d, SF=%d, BW=%d, CR=4/%d, IH=%d\n",
+    LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": TXMODE, freq=%"PRIu32", len=%d, SF=%d, BW=%d, CR=4/%d, IH=%d\n",
            os_getTime(), LMIC.freq, LMIC.dataLen, sf,
            bw == BW125 ? 125 : (bw == BW250 ? 250 : 500),
            cr == CR_4_5 ? 5 : (cr == CR_4_6 ? 6 : (cr == CR_4_7 ? 7 : 8)),
@@ -657,7 +656,7 @@ static void rxlora (u1_t rxmode) {
         opmode(OPMODE_RX_SINGLE);
 #if LMIC_DEBUG_LEVEL > 0
 	ostime_t now = os_getTime();
-	LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"PRId32"\n", now - LMIC.rxtime);
+	LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"LMIC_PRId_ostime_t"\n", now - LMIC.rxtime);
 #endif
     } else { // continous rx (scan or rssi)
         opmode(OPMODE_RX);
@@ -670,7 +669,7 @@ static void rxlora (u1_t rxmode) {
         u1_t sf = getSf(LMIC.rps) + 6; // 1 == SF7
         u1_t bw = getBw(LMIC.rps);
         u1_t cr = getCr(LMIC.rps);
-        LMIC_DEBUG_PRINTF("%"PRId32": %s, freq=%"PRIu32", SF=%d, BW=%d, CR=4/%d, IH=%d\n",
+        LMIC_DEBUG_PRINTF("%"LMIC_PRId_ostime_t": %s, freq=%"PRIu32", SF=%d, BW=%d, CR=4/%d, IH=%d\n",
                os_getTime(),
                rxmode == RXMODE_SINGLE ? "RXMODE_SINGLE" : (rxmode == RXMODE_SCAN ? "RXMODE_SCAN" : "UNKNOWN_RX"),
                LMIC.freq, sf,
@@ -970,7 +969,7 @@ void radio_irq_handler_v2 (u1_t dio, ostime_t now) {
             LMIC.dataLen = 0;
 #if LMIC_DEBUG_LEVEL > 0
 	    ostime_t now2 = os_getTime();
-	    LMIC_DEBUG_PRINTF("rxtimeout: entry: %"PRId32" rxtime: %"PRId32" entry-rxtime: %"PRId32" now-entry: %"PRId32" rxtime-txend: %"PRId32"\n", entry,
+	    LMIC_DEBUG_PRINTF("rxtimeout: entry: %"LMIC_PRId_ostime_t" rxtime: %"LMIC_PRId_ostime_t" entry-rxtime: %"LMIC_PRId_ostime_t" now-entry: %"LMIC_PRId_ostime_t" rxtime-txend: %"LMIC_PRId_ostime_t"\n", entry,
                 LMIC.rxtime, entry - LMIC.rxtime, now2 - entry, LMIC.rxtime-LMIC.txend);
 #endif
         }

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -921,8 +921,13 @@ void radio_irq_handler (u1_t dio) {
     radio_irq_handler_v2(dio, os_getTime());
 }
 
-void radio_irq_handler_v2 (UNUSED_VAR u1_t dio, ostime_t now) {
+void radio_irq_handler_v2 (u1_t dio, ostime_t now) {
+    LMIC_API_PARAMETER(dio);
+
 #if CFG_TxContinuousMode
+    // in continuous mode, we don't use the now parameter.
+    LMIC_UNREFERENCED_PARAMETER(now);
+
     // clear radio IRQ flags
     writeReg(LORARegIrqFlags, 0xFF);
     u1_t p = readReg(LORARegFifoAddrPtr);

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -920,7 +920,7 @@ void radio_irq_handler (u1_t dio) {
     radio_irq_handler_v2(dio, os_getTime());
 }
 
-void radio_irq_handler_v2 (u1_t dio, ostime_t now) {
+void radio_irq_handler_v2 (UNUSED_VAR u1_t dio, ostime_t now) {
 #if CFG_TxContinuousMode
     // clear radio IRQ flags
     writeReg(LORARegIrqFlags, 0xFF);

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -28,6 +28,7 @@
 
 #define LMIC_DR_LEGACY 0
 
+#include <inttypes.h>
 #include "lmic.h"
 
 // ----------------------------------------
@@ -549,7 +550,7 @@ static void txlora () {
     u1_t sf = getSf(LMIC.rps) + 6; // 1 == SF7
     u1_t bw = getBw(LMIC.rps);
     u1_t cr = getCr(LMIC.rps);
-    LMIC_DEBUG_PRINTF("%lu: TXMODE, freq=%lu, len=%d, SF=%d, BW=%d, CR=4/%d, IH=%d\n",
+    LMIC_DEBUG_PRINTF("%"PRId32": TXMODE, freq=%"PRIu32", len=%d, SF=%d, BW=%d, CR=4/%d, IH=%d\n",
            os_getTime(), LMIC.freq, LMIC.dataLen, sf,
            bw == BW125 ? 125 : (bw == BW250 ? 250 : 500),
            cr == CR_4_5 ? 5 : (cr == CR_4_6 ? 6 : (cr == CR_4_7 ? 7 : 8)),
@@ -656,7 +657,7 @@ static void rxlora (u1_t rxmode) {
         opmode(OPMODE_RX_SINGLE);
 #if LMIC_DEBUG_LEVEL > 0
 	ostime_t now = os_getTime();
-	LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %lu\n", now - LMIC.rxtime);
+	LMIC_DEBUG_PRINTF("start single rx: now-rxtime: %"PRId32"\n", now - LMIC.rxtime);
 #endif
     } else { // continous rx (scan or rssi)
         opmode(OPMODE_RX);
@@ -669,7 +670,7 @@ static void rxlora (u1_t rxmode) {
         u1_t sf = getSf(LMIC.rps) + 6; // 1 == SF7
         u1_t bw = getBw(LMIC.rps);
         u1_t cr = getCr(LMIC.rps);
-        LMIC_DEBUG_PRINTF("%lu: %s, freq=%lu, SF=%d, BW=%d, CR=4/%d, IH=%d\n",
+        LMIC_DEBUG_PRINTF("%"PRId32": %s, freq=%"PRIu32", SF=%d, BW=%d, CR=4/%d, IH=%d\n",
                os_getTime(),
                rxmode == RXMODE_SINGLE ? "RXMODE_SINGLE" : (rxmode == RXMODE_SCAN ? "RXMODE_SCAN" : "UNKNOWN_RX"),
                LMIC.freq, sf,
@@ -964,7 +965,8 @@ void radio_irq_handler_v2 (UNUSED_VAR u1_t dio, ostime_t now) {
             LMIC.dataLen = 0;
 #if LMIC_DEBUG_LEVEL > 0
 	    ostime_t now2 = os_getTime();
-	    LMIC_DEBUG_PRINTF("rxtimeout: entry: %lu rxtime: %lu entry-rxtime: %lu now-entry: %lu rxtime-txend: %lu\n", entry, LMIC.rxtime, entry - LMIC.rxtime, now2 - entry, LMIC.rxtime-LMIC.txend);
+	    LMIC_DEBUG_PRINTF("rxtimeout: entry: %"PRId32" rxtime: %"PRId32" entry-rxtime: %"PRId32" now-entry: %"PRId32" rxtime-txend: %"PRId32"\n", entry,
+                LMIC.rxtime, entry - LMIC.rxtime, now2 - entry, LMIC.rxtime-LMIC.txend);
 #endif
         }
         // mask all radio IRQs


### PR DESCRIPTION
I looked over the changes, rebased onto my travis changes, and touched up a few things per our discussions.

In reviewing this, I found that lmic.c had `extern inline` declarations. This is a very bad idea. By taking them out, and changing lorabase.h to export these as `static inline`, I fixed one of the problems (without deleting an API).  I don't want to use a direct annotation on the function header, because that would tie the code to gcc; instead I used `LMIC_UNREFERENCED_PARAMETER()`, etc.  Compiles clean in travis for esp32.