### PR TITLE
Final polishing...

### DIFF
--- a/src/lmic/lmic.c
+++ b/src/lmic/lmic.c
@@ -31,7 +31,6 @@
 //! \file
 #define LMIC_DR_LEGACY 0
 #include "lmic_bandplan.h"
-#include "inttypes.h"
 
 #if defined(DISABLE_BEACONS) && !defined(DISABLE_PING)
 #error Ping needs beacon tracking

--- a/src/lmic/oslmic.h
+++ b/src/lmic/oslmic.h
@@ -90,7 +90,6 @@ typedef              s4_t  ostime_t;
 #define TYPEDEF_xref2osjob_t   typedef       osjob_t* xref2osjob_t
 
 #define SIZEOFEXPR(x) sizeof(x)
-#define UNUSED_VAR __attribute__((unused))
 
 //----------------------------------------------------------------------------
 // Annotations to avoid various "unused" warnings. These must appear as a

--- a/src/lmic/radio.c
+++ b/src/lmic/radio.c
@@ -28,7 +28,6 @@
 
 #define LMIC_DR_LEGACY 0
 
-#include <inttypes.h>
 #include "lmic.h"
 
 // ----------------------------------------


### PR DESCRIPTION
Hi again,

Thanks again for your work on this. I'd like to suggest two changes:

1. https://github.com/manuelbl/arduino-lmic/commit/8b29ea391992c2292bf2c68ed3e484ec5809f6ff reverting the `#include <inttypes.h>` from lmic.c and radio.c; symbols from inttypes are not used unless debugging, and even then, os.lmic.h is already including it if needed.

2. https://github.com/manuelbl/arduino-lmic/commit/8a8b1cfe1184404224cc86d72a627f972f05c737 remove `UNUSED_VAR`, as it's no longer used, and it doesn't begin with `LMIC_` (so is likely to cause namespace collision headaches in the future).

Let me know what you think.

Best regards,
--Terry